### PR TITLE
Fix function name mismatch in error messages for upscaling operations

### DIFF
--- a/src/vsplugin.c
+++ b/src/vsplugin.c
@@ -222,19 +222,26 @@ static void VS_CC descale_create(const VSMap *in, VSMap *out, void *user_data, V
 
     switch(params.mode) {
         case DESCALE_MODE_BILINEAR:
-            funcname = "Debilinear"; break;
+            funcname = params.upscale ? "Bilinear" : "Debilinear"; 
+            break;
         case DESCALE_MODE_BICUBIC:
-            funcname = "Debicubic"; break;
+            funcname = params.upscale ? "Bicubic" : "Debicubic"; 
+            break;
         case DESCALE_MODE_LANCZOS:
-            funcname = "Delanczos"; break;
+            funcname = params.upscale ? "Lanczos" : "Delanczos"; 
+            break;
         case DESCALE_MODE_SPLINE16:
-            funcname = "Despline16"; break;
+            funcname = params.upscale ? "Spline16" : "Despline16"; 
+            break;
         case DESCALE_MODE_SPLINE36:
-            funcname = "Despline36"; break;
+            funcname = params.upscale ? "Spline36" : "Despline36"; 
+            break;
         case DESCALE_MODE_SPLINE64:
-            funcname = "Despline64"; break;
+            funcname = params.upscale ? "Spline64" : "Despline64"; 
+            break;
         case DESCALE_MODE_CUSTOM:
-            funcname = "Decustom"; break;
+            funcname = params.upscale ? "ScaleCustom" : "Decustom"; 
+            break;
         default:
             vsapi->mapSetError(out, get_error("Descale", "Wrong API use!"));
             return;


### PR DESCRIPTION
The current implementation always uses the "De-" prefixed function names (e.g., "Debicubic") in error messages, even when performing upscaling operations. This causes confusing error messages where an upscaling operation. For example, "Bicubic" shows an error message starting with "Debicubic".

This PR modifies the function name assignment to properly reflect whether the operation is upscaling or downscaling, ensuring that error messages match the actual function being called.