### PR TITLE
fix build issue

### DIFF
--- a/src/vsplugin.c
+++ b/src/vsplugin.c
@@ -26,8 +26,8 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <vapoursynth/VapourSynth4.h>
-#include <vapoursynth/VSHelper4.h>
+#include <VapourSynth4.h>
+#include <VSHelper4.h>
 #include "descale.h"
 #include "plugin.h"
 


### PR DESCRIPTION
```
FAILED: libdescale.dylib.p/src_vsplugin.c.o 
/opt/homebrew/opt/llvm/bin/clang -Ilibdescale.dylib.p -I. -I.. -I../include -I../src -I/opt/homebrew/Cellar/vapoursynth/HEAD-5e1b2a6/include/vapoursynth -I/opt/homebrew/Cellar/zimg/HEAD-9a9a8ea/include -fdiagnostics-color=always -DNDEBUG -Wall -Winvalid-pch -std=c99 -O3 -D_XOPEN_SOURCE=700 -MD -MQ libdescale.dylib.p/src_vsplugin.c.o -MF libdescale.dylib.p/src_vsplugin.c.o.d -o libdescale.dylib.p/src_vsplugin.c.o -c ../src/vsplugin.c
../src/vsplugin.c:29:10: fatal error: 'vapoursynth/VapourSynth4.h' file not found
   29 | #include <vapoursynth/VapourSynth4.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

This patch fixes the error.